### PR TITLE
Update Localizable.strings

### DIFF
--- a/it.lproj/Localizable.strings
+++ b/it.lproj/Localizable.strings
@@ -2,6 +2,8 @@
 "REQUIRES_RESPRING" = "Cambiare questa impostazione richiede un respring.";
 "APPHEADS_SETTINGS" = "Impostazioni AppHeads";
 "ENABLE_FOR_ALL_APPS" = "Abilita per tutte le applicazioni";
+"ENABLED_APPS" = "Abilita applicazioni";
+"ENABLED_APPS_INFO" = "Di default tutte le app sono abilitate. Puoi scegliere se usare solo alcune app come AppHeads qui.";
 "SHOW_HIDE_ACTION" = "Mostra / Nascondi";
 "SHOW_HIDE_DESCRIPTION" = "Assegna un'azione di Activator per mostrare / nascondere AppHeads.";
 "DESIGN_VIEW" = "Personalizza le Live View";


### PR DESCRIPTION
i Fix  for italian language  "enabled apps" and "enabled apps info" strings that didn't exist before (on iphone doesent' appear due there aren't on localization.strings
